### PR TITLE
feat: add docs + minor fixes

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,14 @@
+# Environment variables used for development build on `yarn start`
+
+# openzeppelin defender relay API key
+RELAY_KEY=
+# openzeppeling defender relay secret
+RELAY_SECRET=
+
+# supabase DB URL
+SUPABASE_URL=
+# supabase DB secret key
+SUPABASE_KEY=
+
+# fund amount in wei
+CLAIM_FEE=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # faucet
 Faucet cloudflare worker for prefunding bounty hunters' addresses
+
+## How it works
+1. Some 3rd party service (for example [ubiquity bot](https://github.com/ubiquity/ubiquibot)) sends a `POST` request with the `address` query param, for example: `https://ubq-faucet.workers.dev/?address=0x01`
+2. [Openzeppelin Defender Relay](https://docs.openzeppelin.com/defender/v2/manage/relayers) service prefunds the `0x01` address with some gas payment tokens (`XDAI`, `ETH`, etc...) if the following conditions are met:
+    - wallet address exists in the ubiquity bot's DB (i.e. the wallet is registered by some bounty hunter)
+    - this is the 1st issue solved by a bounty hunter (i.e. the registered wallet address hasn't got any permits)
+    - wallet address has 0 gas tokens amount
+
+## How to run locally
+1. Setup env variables in the `.dev.vars` file:
+```
+# Environment variables used for development build on `yarn start`
+
+# openzeppelin defender relay API key
+RELAY_KEY=
+# openzeppeling defender relay secret
+RELAY_SECRET=
+
+# supabase DB URL
+SUPABASE_URL=
+# supabase DB secret key
+SUPABASE_KEY=
+
+# fund amount in wei
+CLAIM_FEE=
+```
+2. Run `yarn start` to start a local cloudflare worker instance

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,16 +45,16 @@ export default {
 
     const { data } = await supabase.from("wallets").select("wallet_address").eq("wallet_address", ethAddress);
 
-    if (data.length === 0) {
+    if (!data || data.length === 0) {
       return makeRpcResponse({ error: { code: -32000, message: "Address not found" } }, 400);
     }
 
     // Searching using github api might not return all users so I'm sticking to the db
     // this can be worked around if they change their registered wallet address
     // but it's inherently abuse-proof as to get a subsidy you must have a permit == need a contribution for 0.0003 eth/xdai
-    const { data: addressInPermits } = await supabase.from("permits").select("bounty_hunter_address").eq("bounty_hunter_address", ethAddress);
+    const { data: permits } = await supabase.from("permits").select("bounty_hunter_address").eq("bounty_hunter_address", ethAddress);
 
-    if (addressInPermits) {
+    if (permits && permits.length > 0) {
       return makeRpcResponse({ error: { code: -32000, message: "Has likely been subsidized before." } }, 400);
     }
 


### PR DESCRIPTION
This PR:
1. Adds some docs
2. Fixes small ts issue [here](https://github.com/ubq-testing/faucet/pull/1/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R48)
3. Checks array length [here](https://github.com/ubq-testing/faucet/pull/1/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R57) because `await supabase.from("permits").select("bounty_hunter_address").eq("bounty_hunter_address", ethAddress);` always returns an array and in case there are no permits then `if([])` resolves to `true` hence the `Has likely been subsidized before` error is shown even for users without permits